### PR TITLE
fix: improve neovim installation script

### DIFF
--- a/.chezmoiscripts/linux/run_onchange_install-neovim.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-neovim.sh
@@ -1,57 +1,120 @@
 #!/bin/bash
+# Script: run_onchange_install-neovim.sh
+# Description: Installs or updates Neovim using AppImage distribution method
+# Requirements:
+#   - Linux x86_64
+#   - curl
+#   - Optional: FUSE support for direct AppImage execution
 set -eu
 
-install_from_source() {
-  local version=$1
-  local tmp_dir=$2
-  echo "Installing Neovim ${version} from source..."
-  
-  # Download source code
-  cd "${tmp_dir}"
-  curl -L "https://github.com/neovim/neovim/archive/refs/tags/${version}.tar.gz" -o nvim-source.tar.gz || { echo "Failed to download Neovim source"; exit 1; }
-  tar xzf nvim-source.tar.gz || { echo "Failed to extract Neovim source"; exit 1; }
-  cd "neovim-${version#v}"
-
-  # Build with CMAKE_BUILD_TYPE=RelWithDebInfo for better compatibility
-  echo "Building Neovim from source (this may take a while)..."
-  make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_INSTALL_PREFIX="${HOME}/.local" || { echo "Failed to build Neovim"; exit 1; }
-  make install || { echo "Failed to install Neovim"; exit 1; }
-  cd ..
+# Check if FUSE is available on the system
+# Returns:
+#   0 if FUSE is available
+#   1 if FUSE is not available
+check_fuse() {
+  if command -v fusermount > /dev/null 2>&1 && grep -q fuse /proc/filesystems; then
+    return 0
+  else
+    return 1
+  fi
 }
 
-# Install neovim on Linux in user space
-if ! command -v nvim > /dev/null 2>&1; then
-  echo "Installing neovim..."
-
-  # Create directories
-  mkdir -p "${HOME}/.local/bin"
-  mkdir -p "${HOME}/.local/share/nvim"
-  mkdir -p "${HOME}/.config/nvim"
-
-  # Default fallback version
-  FALLBACK_VERSION="v0.10.4"
-
-  # Get latest release from GitHub
-  echo "Getting latest Neovim release version..."
-  API_RESPONSE=$(curl -s https://api.github.com/repos/neovim/neovim/releases/latest)
+# Get the latest available version from GitHub
+get_latest_version() {
+  local is_legacy=$1
+  local repo="neovim/neovim"
+  [ "$is_legacy" = "true" ] && repo="neovim/neovim-releases"
   
-  # Try to extract the version number
-  NVIM_VERSION=$(echo "$API_RESPONSE" | grep -o '"tag_name": "v[^"]*"' | grep -o 'v[0-9.]*') || true
-  if [ -z "$NVIM_VERSION" ]; then
-    echo "Error: Could not get latest version number from GitHub API"
-    echo "Using fallback version ${FALLBACK_VERSION}"
-    NVIM_VERSION="$FALLBACK_VERSION"
-  else
-    echo "Latest Neovim version: $NVIM_VERSION"
+  local API_RESPONSE=$(curl -s "https://api.github.com/repos/${repo}/releases/latest")
+  local VERSION=$(echo "$API_RESPONSE" | grep -o '"tag_name": "v[^"]*"' | grep -o 'v[0-9.]*')
+  if [ -z "$VERSION" ]; then
+    VERSION="v0.11.0"  # Fallback to known stable version
+  fi
+  echo "$VERSION"
+}
+
+# Get current installed version
+get_current_version() {
+  nvim --version | head -n1 | grep -o 'v[0-9.]*'
+}
+
+# Install or update Neovim using AppImage distribution method
+# The function automatically handles:
+# - FUSE vs no-FUSE systems
+# - Modern (glibc >= 2.12) vs legacy systems
+# - GitHub API fallback with stable version
+install_or_update_appimage() {
+  local install_dir="${HOME}/.local/bin"
+  
+  # Extract glibc version using ldd
+  local glibc_version=$(ldd --version | head -n1 | grep -o '[0-9.]*$')
+  echo "Detected glibc version: ${glibc_version}"
+
+  # Compare glibc versions using sort -V for proper version comparison
+  local is_legacy=false
+  if ! printf '%s\n%s\n' "2.34" "$glibc_version" | sort -V | head -n1 | grep -q "^2.34$"; then
+    is_legacy=true
   fi
 
-  # Create temporary directory and build from source
-  TMP_DIR=$(mktemp -d)
-  install_from_source "$NVIM_VERSION" "$TMP_DIR"
+  # Get latest version
+  local NVIM_VERSION=$(get_latest_version "$is_legacy")
+  
+  # For updates, check if we already have the latest version
+  if command -v nvim > /dev/null 2>&1; then
+    local CURRENT_VERSION=$(get_current_version)
+    if [ "$CURRENT_VERSION" = "$NVIM_VERSION" ]; then
+      echo "Neovim is already at the latest version ($NVIM_VERSION)"
+      return 0
+    fi
+    echo "Updating Neovim from $CURRENT_VERSION to $NVIM_VERSION"
+  else
+    echo "Installing Neovim $NVIM_VERSION"
+  fi
 
-  # Clean up
-  rm -rf "${TMP_DIR}"
-  echo "Neovim ${NVIM_VERSION} installation completed"
-else
-  echo "neovim is already installed."
-fi
+  # Set download URL based on system compatibility
+  if [ "$is_legacy" = "true" ]; then
+    echo "Using unsupported binary (glibc < 2.34)"
+    local download_url="https://github.com/neovim/neovim-releases/releases/download/${NVIM_VERSION}/nvim-linux-x86_64.appimage"
+  else
+    echo "Using standard AppImage (glibc >= 2.34)"
+    local download_url="https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim.appimage"
+  fi
+
+  local appimage_path="${install_dir}/nvim.appimage"
+  
+  # Download AppImage with error handling
+  echo "Downloading Neovim AppImage from ${download_url}..."
+  curl -L "${download_url}" -o "${appimage_path}" || { echo "Failed to download Neovim AppImage"; exit 1; }
+  chmod u+x "${appimage_path}"
+
+  # Handle FUSE vs no-FUSE systems
+  if ! check_fuse; then
+    echo "FUSE is not available, extracting AppImage..."
+    cd "${install_dir}"
+    local extract_dir="${install_dir}/nvim-extracted"
+    # Clean up old extracted version if it exists
+    rm -rf "${extract_dir}"
+    mkdir -p "${extract_dir}"
+    
+    # Extract AppImage contents to directory (cd first to extract in the right location)
+    cd "${extract_dir}"
+    "${appimage_path}" --appimage-extract || { echo "Failed to extract AppImage"; exit 1; }
+    ln -sf "${extract_dir}/squashfs-root/usr/bin/nvim" "${install_dir}/nvim"
+    rm -f "${appimage_path}"  # Remove AppImage after successful extraction
+  else
+    echo "FUSE is available, using AppImage directly"
+    ln -sf "${appimage_path}" "${install_dir}/nvim"
+  fi
+  
+  # Verify installation succeeded
+  "${install_dir}/nvim" --version || { echo "Failed to verify Neovim installation"; exit 1; }
+  echo "Neovim ${NVIM_VERSION} installation completed successfully"
+}
+
+# Create required directories if they don't exist
+mkdir -p "${HOME}/.local/bin"      # For the binary
+mkdir -p "${HOME}/.local/share/nvim"  # For plugins and data
+mkdir -p "${HOME}/.config/nvim"      # For configuration
+
+# Install or update Neovim
+install_or_update_appimage

--- a/.chezmoiscripts/linux/run_onchange_install-neovim.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-neovim.sh
@@ -84,7 +84,7 @@ install_or_update_appimage() {
   
   # Download AppImage with error handling
   echo "Downloading Neovim AppImage from ${download_url}..."
-  curl -L "${download_url}" -o "${appimage_path}" || { echo "Failed to download Neovim AppImage"; exit 1; }
+  curl -L "${download_url}" -o "${appimage_path}" || { echo "Failed to download Neovim AppImage from ${download_url}"; exit 1; }
   chmod u+x "${appimage_path}"
 
   # Handle FUSE vs no-FUSE systems
@@ -93,12 +93,12 @@ install_or_update_appimage() {
     cd "${install_dir}"
     local extract_dir="${install_dir}/nvim-extracted"
     # Clean up old extracted version if it exists
-    rm -rf "${extract_dir}"
+    [ -d "${extract_dir}" ] && rm -rf "${extract_dir}"
     mkdir -p "${extract_dir}"
     
     # Extract AppImage contents to directory (cd first to extract in the right location)
     cd "${extract_dir}"
-    "${appimage_path}" --appimage-extract || { echo "Failed to extract AppImage"; exit 1; }
+    "${appimage_path}" --appimage-extract || { echo "Failed to extract AppImage (check disk space and permissions)"; exit 1; }
     ln -sf "${extract_dir}/squashfs-root/usr/bin/nvim" "${install_dir}/nvim"
     rm -f "${appimage_path}"  # Remove AppImage after successful extraction
   else
@@ -107,7 +107,7 @@ install_or_update_appimage() {
   fi
   
   # Verify installation succeeded
-  "${install_dir}/nvim" --version || { echo "Failed to verify Neovim installation"; exit 1; }
+  "${install_dir}/nvim" --version || { echo "Failed to verify Neovim installation (expected ${NVIM_VERSION})"; exit 1; }
   echo "Neovim ${NVIM_VERSION} installation completed successfully"
 }
 


### PR DESCRIPTION
## Changes
- Update AppImage installation process to handle different glibc versions (>= 2.34 and < 2.34)
- Add automatic update functionality that checks current version against latest available
- Fix AppImage extraction for non-FUSE systems using correct extraction path
- Use correct download URLs from appropriate repositories based on system compatibility
- Add better error handling and version verification
- Clean up old extracted versions during updates

## Testing
The script has been tested to work with:
- Systems with and without FUSE support
- Different glibc versions
- Fresh installations and updates
- Both supported and unsupported (legacy) systems

## Notes
- For modern systems (glibc >= 2.34), downloads from neovim/neovim releases
- For legacy systems (glibc < 2.34), downloads from neovim/neovim-releases

- Automatically extracts AppImage if FUSE is not available
- Verifies installation by checking neovim version after setup