### PR TITLE
Fix wezterm terminal compatibility issue

### DIFF
--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -8,11 +8,7 @@
 set -gx EDITOR nvim
 set -gx VISUAL nvim
 # Use a widely supported terminal type
-if test "$SSH_TTY" != ""
-    set -gx TERM xterm-256color
-else
-    set -gx TERM wezterm
-end
+set -gx TERM xterm-256color
 
 # Theme configuration
 # Set fish to use Catppuccin Mocha theme by default

--- a/dot_wezterm.lua.tmpl
+++ b/dot_wezterm.lua.tmpl
@@ -265,7 +265,7 @@ config.switch_to_last_active_tab_when_closing_tab = true
 config.tab_bar_at_bottom = true
 config.scroll_to_bottom_on_input = true
 config.show_new_tab_button_in_tab_bar = false
-config.term = 'wezterm'
+config.term = 'xterm-256color'  -- Changed from 'wezterm' to 'xterm-256color' for better compatibility
 config.use_dead_keys = true
 config.use_fancy_tab_bar = false
 config.window_padding = { left = 0, right = 0, top = 0, bottom = '.5cell' }


### PR DESCRIPTION
This PR resolves the issue with wezterm terminal compatibility by setting TERM consistently to xterm-256color in both fish and wezterm configurations. This eliminates the warning message: 'Could not set up terminal for $TERM wezterm. Falling back to hardcoded xterm-256color values'.