### PR TITLE
Fix: Remove Catppuccin Mocha theme from fish config

### DIFF
--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -10,10 +10,6 @@ set -gx VISUAL nvim
 # Use a widely supported terminal type
 set -gx TERM xterm-256color
 
-# Theme configuration
-# Set fish to use Catppuccin Mocha theme by default
-fish_config theme choose "Catppuccin Mocha"
-
 # WezTerm specific settings
 if test "$TERM_PROGRAM" = WezTerm
     # Enable true color support and italics


### PR DESCRIPTION
This PR fixes the error 'No such theme: Catppuccin Mocha' that appears at fish startup by removing the theme setting from fish config. It relies on wezterm's theme configuration instead.