### PR TITLE
Improve macOS support and path handling

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -19,6 +19,7 @@ packages:
       - 'mactop'
       - 'rust'
       - 'git-extras'
+      - 'ripgrep'
       - 'pixi'
     casks:
       - 'wezterm'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ A cross-platform dotfiles template managed with [chezmoi](https://chezmoi.io/). 
 
 ## Quick Start 🚀
 
+### macOS Prerequisites
+
+⚠️ **Important for macOS users:** Before installing these dotfiles, you must first:
+
+1. Install [Homebrew](https://brew.sh/) by running:
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+2. Install GitHub CLI using Homebrew:
+   ```bash
+   brew install gh
+   ```
+
+3. Authenticate with GitHub:
+   ```bash
+   gh auth login
+   ```
+
+These steps are essential as the dotfiles rely heavily on Homebrew for package management on macOS.
+
 ### One-Line Installation
 
 ```bash
@@ -38,10 +59,16 @@ Learn more about Codespaces dotfiles in the [official documentation](https://doc
 
 ## Prerequisites ✅
 
+### For All Platforms
 - A GitHub account (for git and GitHub-related features)
   - GitHub CLI authentication will be handled automatically during installation
   - For non-interactive environments, set `GH_TOKEN` environment variable before installation
 - SSH keys added to your GitHub account ([instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent))
+
+### macOS Specific
+- [Homebrew](https://brew.sh/) package manager (see [macOS Prerequisites](#macos-prerequisites) above)
+- GitHub CLI installed via Homebrew
+- Note: Many tools in these dotfiles depend on Homebrew-installed packages on macOS
 
 ## Common Tasks 🛠️
 

--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -1,6 +1,23 @@
 # Fish shell configuration file
 
 ###########################################
+# HOMEBREW INITIALIZATION - MUST COME FIRST
+###########################################
+
+{{ if eq .chezmoi.os "darwin" -}}
+# Initialize Homebrew first to ensure correct binary paths
+if command -v brew >/dev/null 2>&1
+    # Use brew shellenv to properly set up all Homebrew environment variables
+    eval "$(brew shellenv)"
+end
+{{- end }}
+
+# Add ~/.local/bin to PATH if it exists
+if test -d $HOME/.local/bin
+    fish_add_path $HOME/.local/bin
+end
+
+###########################################
 # ENVIRONMENT VARIABLES
 ###########################################
 
@@ -25,21 +42,7 @@ end
 # PATH CONFIGURATION
 ###########################################
 
-{{ if eq .chezmoi.os "darwin" -}}
-# Configure Homebrew paths based on architecture
-if test -d /opt/homebrew
-    # Apple Silicon (M1/M2) Mac
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-else if test -d /usr/local/Homebrew
-    # Intel Mac
-    eval "$(/usr/local/bin/brew shellenv)"
-end
-{{- end }}
 
-# Add ~/.local/bin to PATH if it exists
-if test -d $HOME/.local/bin
-    fish_add_path $HOME/.local/bin
-end
 
 # Add fzf bin directory to PATH if it exists
 if test -d $HOME/.fzf/bin
@@ -54,17 +57,14 @@ end
 # Google Cloud SDK configuration
 {{ if eq .chezmoi.os "darwin" -}}
 # Check for Google Cloud SDK in Homebrew locations on macOS
-if test -d /opt/homebrew/Caskroom/google-cloud-sdk
-    fish_add_path /opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin
+if command -v brew >/dev/null 2>&1
+    set -l brew_prefix (brew --prefix)
+    if test -d "$brew_prefix/Caskroom/google-cloud-sdk"
+        fish_add_path "$brew_prefix/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin"
 
-    if test -f /opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.fish.inc
-        source /opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.fish.inc
-    end
-else if test -d /usr/local/Caskroom/google-cloud-sdk
-    fish_add_path /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin
-
-    if test -f /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.fish.inc
-        source /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.fish.inc
+        if test -f "$brew_prefix/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.fish.inc"
+            source "$brew_prefix/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.fish.inc"
+        end
     end
 end
 {{ else -}}

--- a/dot_zprofile.tmpl
+++ b/dot_zprofile.tmpl
@@ -1,4 +1,16 @@
 # chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
+# [[ if eq .chezmoi.os "darwin" -}}
+# Initialize Homebrew if available
+if [ -x "$(command -v brew)" ]; then
+  eval "$(brew shellenv)"
+fi
+# [[ else -}}
+# Add ~/.local/bin to PATH on Linux if it exists
+if [ -d "$HOME/.local/bin" ]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+# [[ end -}}
+
 if [ -x "$(command -v fish)" ]; then
   exec fish
 fi


### PR DESCRIPTION
This PR makes several improvements for macOS users:

1. Adds clear instructions in the README about installing Homebrew and GitHub CLI first
2. Adds ripgrep to the list of macOS brew packages
3. Improves path handling for binaries on both macOS and Linux:
   - Uses brew shellenv in a more robust way for macOS
   - Adds ~/.local/bin to PATH on Linux
   - Ensures Homebrew initialization happens early in fish config
4. Removes architecture-specific code in favor of more portable approaches

These changes will make the dotfiles more reliable across different macOS versions and architectures.