### PR TITLE
Configure inline diff display for git and chezmoi

### DIFF
--- a/dot_config/chezmoi/chezmoi.toml
+++ b/dot_config/chezmoi/chezmoi.toml
@@ -1,0 +1,6 @@
+[diff]
+    command = "difft"
+    args = ["--display=inline", "--color=always", "{{.Destination}}", "{{.Target}}"]
+
+[merge]
+    command = "vimdiff"

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -84,7 +84,7 @@
 
 [diff]
     # Use difftastic for all diffs by default if available
-    external = "command -v difft >/dev/null 2>&1 && difft --display=inline || git diff"
+    external = "command -v difft >/dev/null 2>&1 && difft --display=inline \"$@\" || git diff"
     tool = difftastic
     # Add VSCode as an alternative diff tool
     guitool = vscode


### PR DESCRIPTION
This PR adds configuration to ensure both git diff and chezmoi diff use inline display mode instead of side-by-side, which works better in smaller terminal windows.\n\nChanges:\n- Modified Git config to explicitly use inline diff display with difftastic\n- Added a chezmoi config file to use inline diff display with difft