### PR TITLE
Fix: Update Neovim AppImage download URL

### DIFF
--- a/.chezmoiscripts/linux/run_onchange_install-neovim.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-neovim.sh
@@ -77,7 +77,7 @@ install_or_update_appimage() {
     local download_url="https://github.com/neovim/neovim-releases/releases/download/${NVIM_VERSION}/nvim-linux-x86_64.appimage"
   else
     echo "Using standard AppImage (glibc >= 2.34)"
-    local download_url="https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim.appimage"
+    local download_url="https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.appimage"
   fi
 
   local appimage_path="${install_dir}/nvim.appimage"


### PR DESCRIPTION
## Fix Neovim AppImage Download URL

### Changes
- Updated the Neovim installation script to use the correct AppImage download URL path
- Now using the stable release path: \`https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.appimage\`

### Issue Fixed
This PR fixes an issue where Neovim installation was failing due to an incorrect download URL format. 
The previous URL pattern wasn't working properly, resulting in a \`Not: command not found\` error.

### Testing
Tested the installation script and verified that Neovim now downloads and installs correctly.