### PR TITLE
Add Fish shell installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ A cross-platform dotfiles template managed with [chezmoi](https://chezmoi.io/). 
 
 These steps are essential as the dotfiles rely heavily on Homebrew for package management on macOS.
 
-### One-Line Installation
+### Installation
+
+#### Using Bash/Zsh/Sh
 
 ```bash
 sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin init --apply artefactory/artefiles
+```
+
+#### Using Fish Shell
+
+```fish
+curl -fsLS get.chezmoi.io | sh -s -- -b ~/.local/bin init --apply artefactory/artefiles
 ```
 
 ### GitHub Codespaces Support

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin init --apply artefac
 #### Using Fish Shell
 
 ```fish
-curl -fsLS get.chezmoi.io | sh -s -- -b ~/.local/bin init --apply artefactory/artefiles
+curl -fsLS get.chezmoi.io | sh -s -- -b ~/.local/bin init --apply artefactory/artefiles # Fish shell requires this pipe syntax
 ```
 
 ### GitHub Codespaces Support


### PR DESCRIPTION
This PR adds specific installation instructions for Fish shell users to the README.md file. The original installation command works in Bash/Zsh/Sh but can cause issues in Fish shell due to differences in how the shells handle command substitution and variable expansion. This PR provides a Fish-compatible alternative using pipe syntax instead of command substitution.