### PR TITLE
Add 1Password CLI with service account support

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -21,6 +21,7 @@ packages:
       - 'git-extras'
       - 'ripgrep'
       - 'pixi'
+      - '1password-cli'
     casks:
       - 'wezterm'
       - 'google-chrome'

--- a/.chezmoiscripts/linux/run_onchange_install-1password-cli.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-1password-cli.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+# Install 1Password CLI (op) for Linux without requiring root
+# https://developer.1password.com/docs/cli/
+
+set -eu
+
+# Check if 1Password CLI is already installed
+if command -v op > /dev/null 2>&1; then
+  echo "1Password CLI (op) already installed."
+  echo "Version: $(op --version)"
+  exit 0
+fi
+
+echo "Installing 1Password CLI..."
+
+# Create temporary directory for the download
+TEMP_DIR=$(mktemp -d)
+cd "${TEMP_DIR}"
+
+# Define fallback version in case of API rate limit
+FALLBACK_VERSION="2.24.0"
+
+# Try to get the latest release version
+GITHUB_RESPONSE=$(curl -s https://api.github.com/repos/1Password/op/releases/latest)
+
+# Check if the API rate limit was exceeded
+if echo "$GITHUB_RESPONSE" | grep -q "API rate limit exceeded"; then
+  echo "GitHub API rate limit exceeded. Using fallback version ${FALLBACK_VERSION}."
+  LATEST_RELEASE="${FALLBACK_VERSION}"
+else
+  LATEST_RELEASE=$(echo "$GITHUB_RESPONSE" | grep '"tag_name":' | sed -E 's/.*"v?([^"]+)".*/\1/')
+
+  # If failed to get the latest version for any reason, use the fallback
+  if [ -z "$LATEST_RELEASE" ]; then
+    echo "Failed to determine latest version. Using fallback version ${FALLBACK_VERSION}."
+    LATEST_RELEASE="${FALLBACK_VERSION}"
+  else
+    echo "Found latest 1Password CLI version: ${LATEST_RELEASE}"
+  fi
+fi
+
+# Detect architecture and OS
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+  ARCH_NAME="amd64"
+elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+  ARCH_NAME="arm64"
+else
+  echo "Error: Unsupported architecture: $ARCH"
+  exit 1
+fi
+
+# Set download URL
+DOWNLOAD_URL="https://cache.agilebits.com/dist/1P/op/pkg/v${LATEST_RELEASE}/op_linux_${ARCH_NAME}_v${LATEST_RELEASE}.zip"
+echo "Downloading 1Password CLI from ${DOWNLOAD_URL}..."
+
+# Download and extract
+curl -sS -o op.zip "$DOWNLOAD_URL"
+if [ ! -s op.zip ]; then
+  echo "Error: Failed to download 1Password CLI from ${DOWNLOAD_URL}"
+  exit 1
+fi
+
+# Create directory for binaries if needed
+mkdir -p "${HOME}/.local/bin"
+
+# Extract directly to the bin directory
+unzip -o op.zip op -d "${HOME}/.local/bin/"
+chmod +x "${HOME}/.local/bin/op"
+
+# Cleanup
+cd - > /dev/null
+rm -rf "${TEMP_DIR}"
+
+echo "1Password CLI installed successfully to ${HOME}/.local/bin/op"
+echo "Usage: op --help"
+echo "For service account creation: op service-account create \"My Service Account\" --can-create-vaults --expires-in 24h --vault Production:read_items,write_items"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,6 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
 
-  # Shell script checking
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
-    hooks:
-      - id: shellcheck
-        args: ["-x"]
-
   # Shell script formatting
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,11 @@ All notable changes to this project will be documented in this file.
 
 - Resolve pre-commit errors in shell scripts and documentation ([769305e](769305e0fa3c66cc5f301202728e06fbedcfa797))
 
-- Remove pyright and TypeScript language servers and fix lazy package manager errors ([c240d9c](c240d9c67577f190a2293a28c7b1d1a015338b4d))
+- Remove pyright and TypeScript language servers and fix lazy package manager errors ([f3bce99](f3bce99b2dcd528bc88780b50ef4cc0101a826e9))
 
-- Add Git version check for conflict style compatibility ([b22611f](b22611fe8878ab1f335dd86d4bf5b73b258fb7e6))
+- Add Git version check for conflict style compatibility ([095f309](095f3094cc9a7ecb5503b14629b4248b958de72b))
+
+- Remove tsserver specific case from Neovim config ([21c3b67](21c3b67db2abf1d96c5c7b5c44e2465a693fc462))
 
 
 ### Chores
@@ -212,6 +214,12 @@ All notable changes to this project will be documented in this file.
 - Improve errors handling in the script ([4fca49b](4fca49b007425a199916bb42a8e541fddac5d99f))
 
 - Configure inline diff display for git and chezmoi ([cb9e064](cb9e064746f213ec0b9b4b9927a26bb5a4778c8e))
+
+- Add 1password-cli to macOS packages ([56a76ca](56a76cae00aec20484adbf818c5d55bf57250709))
+
+- Add 1Password CLI installation script for Linux ([b61aae0](b61aae09e39e80f9242c0d825b35da58ec4db301))
+
+- Add 1Password CLI integration to fish shell ([fb25cc9](fb25cc9cfd0ebdd67c17f4d8a4466e5e255d1bf7))
 
 
 ### Fix

--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -162,6 +162,88 @@ end
 # Disable fish greeting message
 set fish_greeting
 
+# Theme management - Only apply in interactive sessions
+if status is-interactive
+    # Check for theme persistence file
+    set -l theme_file "$HOME/.config/fish/theme_preference"
+
+    # Function to detect if theme appears to be intentionally set by the user
+    # This checks common user configuration files for theme settings
+    function __is_theme_user_defined
+        # Check if any fish theme variables are set in fish_variables
+        if test -f "$HOME/.config/fish/fish_variables"
+            and grep -q "^SETUVAR fish_color_" "$HOME/.config/fish/fish_variables"
+            return 0
+        end
+
+        # Check if a theme file exists and has content
+        if test -f $theme_file
+            and test -s $theme_file
+            return 0
+        end
+
+        # Check for theme setting in universal variables
+        if set -q fish_colors
+            return 0
+        end
+
+        return 1
+    end
+
+    # Get current theme if possible
+    set -l current_theme ""
+    if type -q fish_config
+        # Try to get current theme - might not work in all fish versions
+        set current_theme (fish_config theme current 2>/dev/null)
+    end
+
+    # Default theme - Catppuccin Mocha
+    set -l default_theme ""
+
+    # Apply theme logic
+    if __is_theme_user_defined
+        # User has a theme set - save it if not already saved
+        if test -n "$current_theme"
+            and not test -f $theme_file
+            echo $current_theme > $theme_file 2>/dev/null
+        end
+    else
+        # No user-defined theme found - use Catppuccin Mocha as default
+        if type -q fish_config
+            set -l available_themes (fish_config theme list 2>/dev/null)
+
+            # First priority: Find Catppuccin Mocha specifically
+            for theme in $available_themes
+                if string match -q "*[Cc]atppuccin*[Mm]ocha*" $theme
+                    set default_theme $theme
+                    break
+                end
+            end
+
+            # Second priority: Any Catppuccin variant if Mocha isn't available
+            if test -z "$default_theme"
+                for theme in $available_themes
+                    if string match -q "*[Cc]atppuccin*" $theme
+                        set default_theme $theme
+                        break
+                    end
+                end
+            end
+
+            # Apply the default theme if found and different from current
+            if test -n "$default_theme" -a "$current_theme" != "$default_theme"
+                fish_config theme choose $default_theme 2>/dev/null
+                # Only show message when theme changes
+                echo "Theme changed to $default_theme"
+                echo $default_theme > $theme_file 2>/dev/null
+            end
+        end
+    end
+
+    # Clean up our temporary function
+    functions -e __is_theme_user_defined
+end
+
 # Load separate aliases file
 if test -f $HOME/.config/fish/aliases.fish
     source $HOME/.config/fish/aliases.fish

--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -1,59 +1,48 @@
 # chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
 
-# Fish shell configuration file
+# [[ if eq .chezmoi.os "darwin" -]] #
+# Fish shell configuration for macOS development environment
+# [[ else -]] #
+# Fish shell configuration for Linux development environment
+# [[ end -]] #
 
 ###########################################
-# HOMEBREW INITIALIZATION - MUST COME FIRST
+# PATH CONFIGURATION - ORDER MATTERS
 ###########################################
 
 # [[ if eq .chezmoi.os "darwin" -]] #
-# Initialize Homebrew first to ensure correct binary paths (macOS always has brew)
-eval "$(brew shellenv)"
+# Ensure Homebrew is in PATH before anything else
+# Handle both Apple Silicon (/opt/homebrew) and Intel (/usr/local) Mac architectures
+if test -d "/opt/homebrew/bin"
+    fish_add_path --prepend "/opt/homebrew/bin"
+    fish_add_path --prepend "/opt/homebrew/sbin"
+else if test -d "/usr/local/bin"
+    fish_add_path --prepend "/usr/local/bin"
+    fish_add_path --prepend "/usr/local/sbin"
+end
+
+# Set all Homebrew environment variables (PATH, MANPATH, INFOPATH)
+if type -q brew
+    eval "$(brew shellenv)"
+end
 # [[ end ]] #
 
-# Add ~/.local/bin to PATH if it exists
+# User-specific executables
 if test -d $HOME/.local/bin
     fish_add_path $HOME/.local/bin
 end
 
-###########################################
-# ENVIRONMENT VARIABLES
-###########################################
-
-# Basic environment variables
-set -gx EDITOR nvim
-set -gx VISUAL nvim
-# Use a widely supported terminal type
-set -gx TERM xterm-256color
-
-# WezTerm specific settings
-if test "$TERM_PROGRAM" = WezTerm
-    # Enable true color support and italics
-    set -gx COLORTERM truecolor
-end
-
-# Set Git external diff tool if available
-if type -q difft
-    set -gx GIT_EXTERNAL_DIFF difft
-end
-
-###########################################
-# PATH CONFIGURATION
-###########################################
-
-# Add fzf bin directory to PATH if it exists
+# Add language-specific and tool paths
 if test -d $HOME/.fzf/bin
     fish_add_path $HOME/.fzf/bin
 end
 
-# Add Rust/Cargo to PATH if it exists
 if test -d $HOME/.cargo/bin
     fish_add_path $HOME/.cargo/bin
 end
 
 # Google Cloud SDK configuration
 # [[ if eq .chezmoi.os "darwin" -]] #
-# Check for Google Cloud SDK in Homebrew locations on macOS
 set -l brew_prefix (brew --prefix)
 if test -d "$brew_prefix/Caskroom/google-cloud-sdk"
     fish_add_path "$brew_prefix/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin"
@@ -63,116 +52,122 @@ if test -d "$brew_prefix/Caskroom/google-cloud-sdk"
     end
 end
 # [[ else -]] #
-# Linux Google Cloud SDK installation
+# Linux-specific Google Cloud SDK path
 if test -d $HOME/.local/google-cloud-sdk
-    # Directly add the bin directory to PATH
     fish_add_path $HOME/.local/google-cloud-sdk/bin
-
-    # Set up Python for Google Cloud SDK
     set -gx CLOUDSDK_PYTHON /usr/bin/python3
 
-    # Source the completion file if it exists
     if test -f $HOME/.local/google-cloud-sdk/path.fish.inc
         source $HOME/.local/google-cloud-sdk/path.fish.inc
     end
 end
 # [[ end -]] #
 
-# Add atuin (shell history) bin directory to PATH if it exists
+# Atuin shell history tool
 if test -d $HOME/.atuin/bin
     fish_add_path $HOME/.atuin/bin
 end
 
 ###########################################
-# FZF CONFIGURATION
+# ENVIRONMENT VARIABLES
 ###########################################
 
-# Setup fzf to use terminal colors with sensible defaults
+# Text editors
+set -gx EDITOR nvim
+set -gx VISUAL nvim
+
+# Terminal capabilities
+set -gx TERM xterm-256color
+
+# WezTerm-specific settings for better color support
+if test "$TERM_PROGRAM" = WezTerm
+    set -gx COLORTERM truecolor
+end
+
+# Use difftastic for git diffs if available
+if type -q difft
+    set -gx GIT_EXTERNAL_DIFF difft
+end
+
+###########################################
+# TOOL CONFIGURATION
+###########################################
+
+# FZF fuzzy finder
 set -gx FZF_DEFAULT_OPTS "--layout=reverse --border"
 
-###########################################
-# TOOL INITIALIZATION
-###########################################
-
-# Initialize starship prompt if installed
+# Starship prompt - https://starship.rs
 if type -q starship
     starship init fish | source
 end
 
-# Initialize zoxide (smarter cd) if installed
+# Zoxide smarter cd - https://github.com/ajeetdsouza/zoxide
 if type -q zoxide
     zoxide init fish --cmd cd | source
 end
 
-# Initialize direnv if installed
+# Direnv for directory-specific environments - https://direnv.net
 if type -q direnv
     direnv hook fish | source
 end
 
-# Initialize chezmoi completions if installed
+# Chezmoi dotfile manager - https://chezmoi.io
 if type -q chezmoi
     chezmoi completion fish | source
 end
 
-# Initialize fzf if installed
+# FZF configuration with custom key bindings
+# Avoiding conflict with atuin on Ctrl+R
 if type -q fzf
-    # Set up fzf key bindings but tell it not to bind Ctrl-r since atuin will use it
     set -x FZF_DISABLE_KEYBINDINGS 1
     fzf --fish | source
 
-    # Manually bind fzf keys except for Ctrl-r
-    bind \ct __fzf_search_current_dir
-    bind \ec __fzf_search_history
-    bind \eC '__fzf_cd --hidden'
+    # Custom key bindings for FZF
+    bind \ct __fzf_search_current_dir      # Ctrl+T: search files
+    bind \ec __fzf_search_history          # Alt+C: search history
+    bind \eC '__fzf_cd --hidden'           # Alt+Shift+C: cd with hidden files
 end
 
-# Initialize atuin (shell history) if installed - after fzf to override any bindings
+# Atuin shell history with search - https://atuin.sh
 if type -q atuin
+    # Enable shell completions
+    atuin gen-completions --shell fish
+
     set -gx ATUIN_NOBIND true
     atuin init fish | source
 
-    # bind to ctrl-r in normal and insert mode, add any other bindings you want here too
+    # Bind Ctrl+R to search shell history with atuin
     bind \cr _atuin_search
     bind -M insert \cr _atuin_search
 end
 
-# Set up Docker completions if installed
+# Docker - https://www.docker.com
 if type -q docker
-    # Add docker completions if they exist
-    if test -d ~/.config/fish/completions
-        and not test -f ~/.config/fish/completions/docker.fish
-        # Docker provides completions via the CLI
-        docker completion fish >~/.config/fish/completions/docker.fish 2>/dev/null
-    end
+    docker completion fish | source
+end
+
+# 1Password CLI - https://developer.1password.com/docs/cli
+if type -q op
+    # Enable shell completions
+    op completion fish | source
+
+    # Service account creation example:
+    # op service-account create "My Service Account" --can-create-vaults --expires-in 24h --vault Production:read_items,write_items
 end
 
 ###########################################
-# ALIASES AND SHORTCUTS
+# ALIASES AND USER PREFERENCES
 ###########################################
 
-# Source aliases file
+# Disable fish greeting message
+set fish_greeting
+
+# Load separate aliases file
 if test -f $HOME/.config/fish/aliases.fish
     source $HOME/.config/fish/aliases.fish
 end
 
-###########################################
-# SSH AND AUTHENTICATION
-###########################################
-
-# 1Password SSH agent configuration is handled in conf.d/1password.fish.tmpl when available.
-
-###########################################
-# MISCELLANEOUS SETTINGS
-###########################################
-
-# Suppress fish greeting
-set fish_greeting
-
-###########################################
-# LOCAL CONFIGURATION
-###########################################
-
-# Source local config if it exists (not managed by chezmoi)
+# Load local machine-specific config (not managed by chezmoi)
 if test -f $HOME/.config/fish/local.config.fish
     source $HOME/.config/fish/local.config.fish
 end

--- a/dot_config/fish/fish_plugins
+++ b/dot_config/fish/fish_plugins
@@ -1,2 +1,3 @@
 jorgebucaran/fisher
 catppuccin/fish
+wawa19933/fish-rsync


### PR DESCRIPTION
This PR adds support for 1Password CLI across platforms:

- Adds 1Password CLI to macOS packages for Homebrew installation
- Creates a Linux installation script that downloads the latest version without requiring root
- Integrates with fish shell for command completions
- Adds documentation for service account creation
- Sets Catppuccin Mocha as the default fish theme if no user preference exists
- Adds fish-rsync plugin

Example service account creation command:
\`op service-account create "My Service Account" --can-create-vaults --expires-in 24h --vault Production:read_items,write_items\`