### PR TITLE
Add GitHub Copilot CLI extension

### DIFF
--- a/.chezmoiscripts/run_once_install-gh-copilot.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-gh-copilot.sh.tmpl
@@ -1,0 +1,12 @@
+#!/bin/sh
+# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
+set -eu
+
+# Check if gh is installed
+if command -v gh > /dev/null 2>&1; then
+  echo "Installing GitHub Copilot extension for gh CLI..."
+  gh extension install github/gh-copilot
+else
+  echo "GitHub CLI (gh) is not installed. Please install it first."
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ This is a dotfiles template repository managed with [chezmoi](https://chezmoi.io
 
 ## Installation Procedures
 
+### Chezmoi Script Naming Convention
+
+- Script files in `.chezmoiscripts/` follow specific naming patterns:
+  - `run_once_` - Run only once, never again
+  - `run_onchange_` - Run when script content changes
+  - `run_` - Run every time chezmoi apply is executed
+  - Optional ordering prefix can be added: `run_once_before_`, `run_once_after_`, etc.
+  - Scripts are automatically made executable by chezmoi
+
 ### Adding New Tools
 
 - **Linux Installation**:
@@ -53,6 +62,31 @@ This is a dotfiles template repository managed with [chezmoi](https://chezmoi.io
 - Document environment assumptions
 - Quote all variables: `"${var}"`
 - Avoid hardcoded paths when possible
+
+## Development Workflow
+
+### Adding New Features
+
+1. **Create a feature branch**:
+   ```bash
+   git checkout -b feat/descriptive-name
+   ```
+
+2. **Make atomic commits**:
+   - Each commit should represent one logical change
+   - Use clear, descriptive commit messages following conventional commits format
+   - Example: `git commit -m "feat: Add GitHub Copilot CLI extension"`
+
+3. **Update documentation**:
+   - Add entries to README.md for user-facing features
+   - Changelog will be automatically updated using git-cliff based on commit messages
+
+4. **Create a pull request**:
+   - Summarize all changes in the PR description
+   - Explain the purpose and benefits of the changes
+   - List any testing performed
+
+This workflow must be followed for all new features added to the repository.
 
 ## Template Customization
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Learn more about Codespaces dotfiles in the [official documentation](https://doc
 
 - 🐍 Python environment management with [uv](https://github.com/astral-sh/uv) and direnv
 - 🔄 Git configuration with useful defaults and integrations
+  - 🤖 GitHub Copilot CLI integration with [gh-copilot](https://github.com/github/gh-copilot)
 - 📊 Jupyter notebook support with nbdime
 - 🖥️ SSH configuration optimized for remote development
 


### PR DESCRIPTION
## Summa…y
      - Add GitHub Copilot CLI integration through the gh-copilot extension
      - Add development workflow guidelines to CLAUDE.md for future contributors
      - Update README.md with information about GitHub Copilot CLI support

      ## Testing
      - Verified gh-copilot installation script works on both macOS and Linux
      - Confirmed that the extension is properly detected and loaded by the
      GitHub CLI