### PR TITLE
feat: add common abbreviations for fish

### DIFF
--- a/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
@@ -33,13 +33,6 @@ mkdir -p "$FISH_CONF_D_DIR"
 
 cat > "${FISH_CONF_D_DIR}/artefiles_abbrs.fish" <<'EOF'
 # Set useful abbreviations
-abbr -a -- gch 'git checkout'
-abbr -a -- gst 'git status'
-abbr -a -- ga 'git add'
-abbr -a -- gau 'git add -u'
-abbr -a -- gcm 'git commit -m'
-abbr -a -- gpush 'git push'
-abbr -a -- gpull 'git pull'
 abbr -a -- vba 'source .venv/bin/activate.fish'
 abbr -a -- dea 'deactivate'
 abbr -a --position anywhere --set-cursor='%' -- G '| grep "%"'

--- a/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
@@ -26,3 +26,24 @@ if ! fish -c "functions -q fisher" > /dev/null 2>&1; then
 fi
 
 fish -c "fisher update"
+
+# Create a dedicated file for useful Fish abbreviations.
+FISH_CONF_D_DIR="$HOME/.config/fish/conf.d"
+mkdir -p "$FISH_CONF_D_DIR"
+
+fish <<'EOF'
+# Set useful abbreviations
+abbr -a -- gch 'git checkout'
+abbr -a -- gst 'git status'
+abbr -a -- ga 'git add'
+abbr -a -- gau 'git add -u'
+abbr -a -- gcm 'git commit -m'
+abbr -a -- gpush 'git push'
+abbr -a -- gpull 'git pull'
+abbr -a -- vba 'source .venv/bin/activate.fish'
+abbr -a -- dea 'deactivate'
+abbr -a --position anywhere --set-cursor='%' -- G '| grep "%'
+
+# Store them in custom fish config file
+abbr > ~/.config/fish/conf.d/artefiles_abbrs.fish
+EOF

--- a/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
@@ -26,14 +26,3 @@ if ! fish -c "functions -q fisher" > /dev/null 2>&1; then
 fi
 
 fish -c "fisher update"
-
-# Create a dedicated file for useful Fish abbreviations.
-FISH_CONF_D_DIR="$HOME/.config/fish/conf.d"
-mkdir -p "$FISH_CONF_D_DIR"
-
-cat > "${FISH_CONF_D_DIR}/artefiles_abbrs.fish" <<'EOF'
-# Set useful abbreviations
-abbr -a -- vba 'source .venv/bin/activate.fish'
-abbr -a -- dea 'deactivate'
-abbr -a --position anywhere --set-cursor='%' -- G '| grep "%"'
-EOF

--- a/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-fisher.sh.tmpl
@@ -31,7 +31,7 @@ fish -c "fisher update"
 FISH_CONF_D_DIR="$HOME/.config/fish/conf.d"
 mkdir -p "$FISH_CONF_D_DIR"
 
-fish <<'EOF'
+cat > "${FISH_CONF_D_DIR}/artefiles_abbrs.fish" <<'EOF'
 # Set useful abbreviations
 abbr -a -- gch 'git checkout'
 abbr -a -- gst 'git status'
@@ -42,8 +42,5 @@ abbr -a -- gpush 'git push'
 abbr -a -- gpull 'git pull'
 abbr -a -- vba 'source .venv/bin/activate.fish'
 abbr -a -- dea 'deactivate'
-abbr -a --position anywhere --set-cursor='%' -- G '| grep "%'
-
-# Store them in custom fish config file
-abbr > ~/.config/fish/conf.d/artefiles_abbrs.fish
+abbr -a --position anywhere --set-cursor='%' -- G '| grep "%"'
 EOF

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Learn more about Codespaces dotfiles in the [official documentation](https://doc
 ### Fish Shell Configuration ([Fish Shell Documentation](https://fishshell.com/docs/current/))
 - `~/.config/fish/config.fish` - Main Fish shell configuration
 - `~/.config/fish/aliases.fish` - Shell aliases and functions
-- `~/.config/fish/conf.d/artefiles_abbrs.fish` - Fish abbreviations generated during install
+- `~/.config/fish/conf.d/artefiles_abbrs.fish` - Fish abbreviations managed by chezmoi
 - `~/.config/fish/fish_plugins` - Fish plugin list
 - `~/.config/fish/functions/fish_title.fish` - Terminal title function
 - `~/.config/fish/functions/smart_bat.fish` - Enhanced bat function (VSCode-aware)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Learn more about Codespaces dotfiles in the [official documentation](https://doc
 ### Fish Shell Configuration ([Fish Shell Documentation](https://fishshell.com/docs/current/))
 - `~/.config/fish/config.fish` - Main Fish shell configuration
 - `~/.config/fish/aliases.fish` - Shell aliases and functions
+- `~/.config/fish/conf.d/artefiles_abbrs.fish` - Fish abbreviations generated during install
 - `~/.config/fish/fish_plugins` - Fish plugin list
 - `~/.config/fish/functions/fish_title.fish` - Terminal title function
 - `~/.config/fish/functions/smart_bat.fish` - Enhanced bat function (VSCode-aware)

--- a/dot_config/fish/conf.d/private_artefiles_abbrs.fish
+++ b/dot_config/fish/conf.d/private_artefiles_abbrs.fish
@@ -1,0 +1,4 @@
+# Set useful abbreviations
+abbr -a -- vba 'source .venv/bin/activate.fish'
+abbr -a -- dea 'deactivate'
+abbr -a --position anywhere --set-cursor='%' -- G '| grep "%"'


### PR DESCRIPTION
- add abbreviations to `~/.config/fish/conf.d/artefiles_abbrs.fish`

A voir:
On peut les écrire dans `~/.config/fish/conf.d/artefiles_abbrs.fish` ou bien dans `~/.config/fish/aliases.fish`, au choix. Les écrire dans les `aliases.fish` est pratique car tout y est centralisé, mais en même temps je trouve ça pas mal de les séparer pour distinguer l'usage des abbreviations vs alias