### PR TITLE
fix(git): set vscode as default mergetool, remove fugitive

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -125,8 +125,9 @@
     conflictstyle = diff3
     # Always use rebase for merging
     ff = only
-    # Use mergiraf as the default merge tool
-    tool = mergiraf
+    # Use vscode for manual conflict resolution when mergiraf can't auto-resolve
+    # (mergiraf is a merge driver, not a mergetool)
+    tool = vscode
 
 [mergetool "vscode"]
     cmd = code --wait "$MERGED"
@@ -134,10 +135,6 @@
 
 [mergetool "nvim"]
     cmd = nvim -d "$LOCAL" "$REMOTE" "$MERGED" -c 'wincmd J | wincmd ='
-    trustExitCode = true
-
-[mergetool "fugitive"]
-    cmd = nvim -f -c \"Gvdiffsplit!\" \"$MERGED\"
     trustExitCode = true
 
 [mergetool]
@@ -204,8 +201,6 @@
     vsmerge = mergetool --tool=vscode
     # Use neovim for resolving merge conflicts
     nvimmerge = mergetool --tool=nvim
-    # Use fugitive for resolving merge conflicts
-    fugmerge = mergetool --tool=fugitive
 
 [credential]
     # [[ if .credentialHelper -]] #


### PR DESCRIPTION
## Summary

- `merge.tool = mergiraf` was incorrect: mergiraf is a **merge driver** (automatic), not a **mergetool** (interactive). Setting it as `merge.tool` caused unexpected fallback behaviour.
- Set `merge.tool = vscode` for manual conflict resolution when mergiraf cannot auto-resolve.
- Remove `[mergetool "fugitive"]` — redundant (duplicates nvim via a vim plugin).
- Remove `fugmerge` alias.

The `[merge "mergiraf"]` driver configuration is unchanged.

Closes #45