### PR TITLE
docs: add terminal restart note to post-installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ atuin login     # Existing account
 gcloud init  # Set up Google Cloud SDK
 ```
 
+### 4. Restart your terminal or IDE
+
+Restart your terminal (or fully quit and reopen your IDE if using VS Code, Cursor, etc.) for all changes to take effect.
+
 ## [Need Help?](#need-help) 🤔
 
 - Run `dotfiles_doctor` to check your installation


### PR DESCRIPTION
## Summary

Adds a short step 4 to the Post-Installation section reminding users to restart their terminal or IDE after installation.

Users installing from VS Code, Cursor, or other IDEs may not see the dotfiles changes take effect until they fully restart, which can be confusing.

Closes #44