### PR TITLE
feat(fonts): install FiraCode Nerd Font via Homebrew cask

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -26,6 +26,7 @@ packages:
       - 'colima'
       - 'zellij'
     casks:
+      - 'font-fira-code-nerd-font'
       - 'ghostty'
       - 'google-chrome'
       - 'gcloud-cli'


### PR DESCRIPTION
## Summary

Adds `font-fira-code-nerd-font` to the macOS Homebrew casks in `packages.yaml`.

Ghostty is already configured to use `FiraCode Nerd Font` as its primary font, but the font was never installed automatically — causing broken/missing icons in the Starship prompt and everywhere else Nerd Font glyphs are expected.

Closes #49