### PR TITLE
feat: uv config to protect user from recent (<7 days) malicious packages

### DIFF
--- a/dot_config/uv/uv.toml
+++ b/dot_config/uv/uv.toml
@@ -1,0 +1,1 @@
+exclude-newer = "7 days"


### PR DESCRIPTION
Add a UV dot config file, used by uv for tool commands. 
- Limit candidate packages to those that were uploaded prior to the given date, see more [here](https://docs.astral.sh/uv/reference/settings/#dependency-metadata)