### PR TITLE
chore: clean stale refs, forbid Docker Desktop, allow mamba

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -8,16 +8,10 @@ README.md
 {{- end }}
 CHANGELOG.md
 CLAUDE.md
-TODO.md
 CHEATSHEET.md
-TEST.md
 cliff.toml
 Dockerfile.linux
 docker-test.sh
-test-dotfiles.sh
-test-dotfiles.fish
-.install-1password-cli.sh
-scripts/install-wezterm-remote.sh
 
 # OS-specific exclusions
 {{ if eq .chezmoi.os "darwin" }}

--- a/.chezmoiscripts/run_once_remove-conda.sh.tmpl
+++ b/.chezmoiscripts/run_once_remove-conda.sh.tmpl
@@ -34,7 +34,7 @@ remove_conda() {
     if [ -f "$rc_file" ]; then
       echo "Cleaning up $rc_file..."
       tmp_file=$(mktemp)
-      grep -v "conda initialize\|conda.sh\|__conda\|Conda\|miniforge\|mambaforge\|anaconda\|miniconda" "$rc_file" > "$tmp_file" || true
+      grep -v "conda initialize\|conda.sh\|__conda\|Conda\|anaconda\|miniconda" "$rc_file" > "$tmp_file" || true
       mv "$tmp_file" "$rc_file"
     fi
   done
@@ -126,7 +126,6 @@ conda() {
 }
 miniconda() { conda; }
 anaconda() { conda; }
-mamba() { conda; }
 EOF
     fi
   fi

--- a/.chezmoiscripts/run_once_remove-docker-desktop.sh.tmpl
+++ b/.chezmoiscripts/run_once_remove-docker-desktop.sh.tmpl
@@ -1,0 +1,95 @@
+# [[ /* chezmoi:template:left-delimiter="# [[" right-delimiter="]] #" */ ]]
+#!/bin/sh
+
+# Removes Docker Desktop installations (forbidden by company policy).
+# Recommends Colima as a replacement on macOS, native Docker Engine on Linux.
+# [[ if ne .chezmoi.os "windows" ]] #
+
+set -eu
+
+echo "Checking for Docker Desktop installation..."
+
+FOUND_DOCKER_DESKTOP=false
+
+# [[ if eq .chezmoi.os "darwin" ]] #
+# Quit Docker Desktop if running, then remove app and supporting data.
+if [ -d "/Applications/Docker.app" ]; then
+  FOUND_DOCKER_DESKTOP=true
+  echo "Found Docker Desktop at /Applications/Docker.app"
+
+  if pgrep -x "Docker Desktop" > /dev/null 2>&1 || pgrep -x "Docker" > /dev/null 2>&1; then
+    echo "Quitting Docker Desktop..."
+    osascript -e 'quit app "Docker"' > /dev/null 2>&1 || true
+    sleep 2
+  fi
+
+  echo "Removing /Applications/Docker.app (sudo required)..."
+  sudo rm -rf "/Applications/Docker.app"
+fi
+
+for path in \
+  "$HOME/Library/Group Containers/group.com.docker" \
+  "$HOME/Library/Containers/com.docker.docker" \
+  "$HOME/Library/Containers/com.docker.helper" \
+  "$HOME/Library/Application Support/Docker Desktop" \
+  "$HOME/Library/Preferences/com.docker.docker.plist" \
+  "$HOME/Library/Preferences/com.electron.docker-frontend.plist" \
+  "$HOME/Library/Saved Application State/com.electron.docker-frontend.savedState" \
+  "$HOME/Library/Logs/Docker Desktop" \
+  "$HOME/Library/Caches/com.docker.docker" \
+  "$HOME/.docker/desktop"; do
+  if [ -e "$path" ]; then
+    FOUND_DOCKER_DESKTOP=true
+    echo "Removing $path..."
+    rm -rf "$path"
+  fi
+done
+# [[ end ]] #
+
+# [[ if eq .chezmoi.os "linux" ]] #
+# Linux Docker Desktop ships as the docker-desktop package.
+if command -v docker-desktop > /dev/null 2>&1; then
+  FOUND_DOCKER_DESKTOP=true
+  echo "Found docker-desktop in PATH"
+  if command -v apt-get > /dev/null 2>&1 && dpkg -s docker-desktop > /dev/null 2>&1; then
+    echo "Removing docker-desktop via apt (sudo required)..."
+    sudo apt-get remove -y docker-desktop || true
+  elif command -v dnf > /dev/null 2>&1 && rpm -q docker-desktop > /dev/null 2>&1; then
+    echo "Removing docker-desktop via dnf (sudo required)..."
+    sudo dnf remove -y docker-desktop || true
+  fi
+fi
+
+for path in \
+  "$HOME/.docker/desktop" \
+  "$HOME/.config/docker-desktop"; do
+  if [ -e "$path" ]; then
+    FOUND_DOCKER_DESKTOP=true
+    echo "Removing $path..."
+    rm -rf "$path"
+  fi
+done
+# [[ end ]] #
+
+if [ "$FOUND_DOCKER_DESKTOP" = true ]; then
+  echo "Docker Desktop removal complete."
+else
+  echo "No Docker Desktop installation found."
+fi
+
+# Warning file documenting the policy and replacements.
+mkdir -p "$HOME/.local/share"
+cat > "$HOME/.local/share/docker_desktop_warning.txt" << EOF
+This environment prohibits the use of Docker Desktop as part of the dotfiles policy.
+Please use one of the following alternatives:
+- Colima (recommended on macOS): https://github.com/abiosoft/colima
+- Native Docker Engine (Linux): https://docs.docker.com/engine/install/
+
+The 'docker' CLI itself is fine — only Docker Desktop (the GUI/VM bundle) is forbidden.
+
+If you have questions, please consult your team's documentation.
+EOF
+
+echo "Created warning file at $HOME/.local/share/docker_desktop_warning.txt"
+
+# [[ end ]] #

--- a/dot_config/fish/config.fish.tmpl
+++ b/dot_config/fish/config.fish.tmpl
@@ -112,9 +112,6 @@ set -gx VISUAL vi
 # Terminal capabilities
 if test "$TERM_PROGRAM" = ghostty
     set -gx TERM xterm-256color
-else if test "$TERM_PROGRAM" = WezTerm
-    set -gx TERM wezterm
-    set -gx COLORTERM truecolor
 else
     set -gx TERM xterm-256color
 end

--- a/dot_config/fish/functions/dotfiles_doctor.fish
+++ b/dot_config/fish/functions/dotfiles_doctor.fish
@@ -80,9 +80,6 @@ function dotfiles_doctor --description "Check dotfiles health and tool installat
     __check_tool_with_configs "git-lfs" "" "$managed_files"
     __check_tool_with_configs "difft" "" "$managed_files"
     __check_tool_with_configs "gh" "" "$managed_files"
-    # [[ if gt (len (glob ".config/glab-cli")) 0 -]] #
-    __check_tool_with_configs "glab" ".config/glab-cli/config.yml:.config/glab-cli/aliases.yml" "$managed_files"
-    # [[ end ]] #
 
     echo ""
     echo "## Development Tools"

--- a/dot_config/fish/functions/dotfiles_doctor.fish
+++ b/dot_config/fish/functions/dotfiles_doctor.fish
@@ -40,6 +40,55 @@ function __check_tool_with_configs --description "Check tool installation and it
     end
 end
 
+function __check_forbidden_conda --description "Flag conda installations (forbidden by policy)"
+    set -l warning_icon "!"
+    set -l success_icon "✓"
+    set -l found 0
+    for path in "$HOME/anaconda3" "$HOME/miniconda3" "$HOME/anaconda" "$HOME/miniconda" \
+                "$HOME/opt/anaconda3" "$HOME/opt/miniconda3" \
+                "$HOME/.local/anaconda3" "$HOME/.local/miniconda3" "/opt/conda"
+        if test -d $path
+            echo "  $warning_icon conda: forbidden installation at $path"
+            set found 1
+        end
+    end
+    if command -v conda >/dev/null 2>&1
+        echo "  $warning_icon conda: forbidden, found in PATH at "(command -v conda)
+        set found 1
+    end
+    if test $found -eq 0
+        echo "  $success_icon conda: not installed (correct)"
+    end
+end
+
+function __check_forbidden_docker_desktop --description "Flag Docker Desktop (forbidden by policy)"
+    set -l warning_icon "!"
+    set -l success_icon "✓"
+    set -l found 0
+    # [[ if eq .chezmoi.os "darwin" -]] #
+    if test -d "/Applications/Docker.app"
+        echo "  $warning_icon docker-desktop: forbidden, found at /Applications/Docker.app"
+        set found 1
+    end
+    for path in "$HOME/Library/Group Containers/group.com.docker" \
+                "$HOME/Library/Containers/com.docker.docker"
+        if test -d $path
+            echo "  $warning_icon docker-desktop: forbidden support data at $path"
+            set found 1
+        end
+    end
+    # [[ end ]] #
+    # [[ if eq .chezmoi.os "linux" -]] #
+    if command -v docker-desktop >/dev/null 2>&1
+        echo "  $warning_icon docker-desktop: forbidden, found in PATH"
+        set found 1
+    end
+    # [[ end ]] #
+    if test $found -eq 0
+        echo "  $success_icon docker-desktop: not installed (correct — use Colima or Docker Engine)"
+    end
+end
+
 function dotfiles_doctor --description "Check dotfiles health and tool installations"
     set -l success_icon "✓"
     set -l warning_icon "!"
@@ -96,6 +145,11 @@ function dotfiles_doctor --description "Check dotfiles health and tool installat
     # [[ if eq .chezmoi.os "darwin" -]] #
     __check_tool_with_configs "aerospace" ".config/aerospace/aerospace.toml" "$managed_files"
     # [[ end ]] #
+
+    echo ""
+    echo "## Forbidden Tools"
+    __check_forbidden_conda
+    __check_forbidden_docker_desktop
 
     echo ""
     echo "Environment Variables:"

--- a/dot_config/fish/functions/dotfiles_doctor.fish
+++ b/dot_config/fish/functions/dotfiles_doctor.fish
@@ -65,7 +65,6 @@ function dotfiles_doctor --description "Check dotfiles health and tool installat
     echo "## Shell Tools"
     __check_tool_with_configs "fish" ".config/fish/config.fish:.config/fish/aliases.fish" "$managed_files"
     __check_tool_with_configs "starship" ".config/starship.toml" "$managed_files"
-    __check_tool_with_configs "wezterm" ".wezterm.lua" "$managed_files"
 
     echo ""
     echo "## File Utilities"

--- a/dot_config/ghostty/private_config.tmpl
+++ b/dot_config/ghostty/private_config.tmpl
@@ -1,7 +1,6 @@
 # chezmoi:template:left-delimiter="[[ " right-delimiter=" ]] #"
 # ============================================================================
 # Ghostty Configuration
-# Migrated from WezTerm
 # ============================================================================
 
 # ============================================================================
@@ -19,17 +18,17 @@ font-size = 14
 # Line height (cell height adjustment for 1.1 line height equivalent)
 adjust-cell-height = 10%
 
-# Cursor appearance (reverse video like WezTerm's force_reverse_video_cursor)
+# Cursor appearance (reverse video)
 cursor-color = cell-foreground
 cursor-text = cell-background
 
-# Inactive pane dimming (equivalent to WezTerm's inactive_pane_hsb)
+# Inactive pane dimming
 unfocused-split-opacity = 0.7
 
 # Split divider color (optional - defaults to theme appropriate color)
 # split-divider-color = #585b70
 
-# Window padding (minimal like WezTerm)
+# Window padding
 window-padding-x = 0
 window-padding-y = 0,4
 

--- a/tests/stale_refs_lint.bats
+++ b/tests/stale_refs_lint.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# Regression guard against stale references that #66 cleaned up.
+#
+# wezterm and glab are no longer shipped or referenced; this test fails
+# fast if either reappears in fish config or function source.
+
+setup() {
+  load 'helpers/setup'
+}
+
+@test "no wezterm references in dot_config/" {
+  if grep -RIni 'wezterm' "$REPO_ROOT/dot_config/" 2>/dev/null; then
+    echo "wezterm references found in dot_config/ (forbidden — see #66)" >&2
+    return 1
+  fi
+}
+
+@test "no glab references in dotfiles_doctor.fish" {
+  if grep -ni 'glab' "$REPO_ROOT/dot_config/fish/functions/dotfiles_doctor.fish" 2>/dev/null; then
+    echo "glab references found in dotfiles_doctor.fish (forbidden — see #66)" >&2
+    return 1
+  fi
+}
+
+@test ".chezmoiignore does not list previously-removed dead refs" {
+  H=$(mk_fake_home)
+  seed_chezmoi_config "$H" '{"modules":[]}'
+  rendered=$(SSH_CLIENT="dummy 1 2" chezmoi_render "$H" .chezmoiignore)
+
+  # Files that were referenced but never existed in the repo — see #66.
+  for dead in TODO.md TEST.md test-dotfiles.sh test-dotfiles.fish \
+              .install-1password-cli.sh scripts/install-wezterm-remote.sh; do
+    if printf '%s\n' "$rendered" | grep -qF "$dead"; then
+      echo ".chezmoiignore still references removed-as-dead path: $dead" >&2
+      return 1
+    fi
+  done
+}


### PR DESCRIPTION
Closes #66.

Scope expanded beyond the original issue — kept the conda removal script (still useful for fresh installs) and added a parallel Docker Desktop guard. Mamba is no longer blocked.

## Cleanup (#66 original scope)
- `.chezmoiignore`: drop dead refs (`TODO.md`, `TEST.md`, `test-dotfiles.*`, `.install-1password-cli.sh`, `scripts/install-wezterm-remote.sh`)
- Remove `wezterm` references from `config.fish.tmpl`, `dotfiles_doctor.fish`, ghostty config comments
- Remove `glab` from `dotfiles_doctor.fish`

## Policy enforcement (added)
- `fix(conda)`: stop blocking `mamba` (allowed)
- `feat`: new `run_once_remove-docker-desktop.sh.tmpl` mirroring the conda removal pattern — detects `/Applications/Docker.app` + Library data on darwin, `docker-desktop` package on linux, uninstalls and writes policy warning
- `feat(doctor)`: `dotfiles_doctor` now has a "Forbidden Tools" section flagging conda or Docker Desktop drift after install

## Tests
- `tests/stale_refs_lint.bats`: regression guard against wezterm/glab reappearing and against the dead `.chezmoiignore` refs

All 13 bats tests pass locally.