### PR TITLE
ci(claude): allow gh pr create so workflow opens PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,6 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Allow Claude to open PRs after pushing the branch.
+          claude_args: '--allowed-tools Bash(gh pr create:*),Bash(gh pr edit:*)'
 


### PR DESCRIPTION
Without this, Claude pushes branches but stops at "create PR" because `gh pr create` is not in the action's default allowed-tools list. Permissions stay read-only — the action uses its own GitHub App token to push and open PRs, not `GITHUB_TOKEN`.

Fixes the silent no-op observed on the @claude runs for #64 / #65.