### PR TITLE
fix(tests): rewrite readme path-existence as a chezmoi-managed check

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Re-run `chezmoi init` to update your module selection, then `chezmoi apply`.
 - `~/.config/ghostty/config` - Ghostty terminal configuration ([Ghostty Documentation](https://ghostty.org/)) (requires `terminal` module)
 
 ### VS Code Configuration
-- `~/.config/Code/User/settings.json` *(Linux)* / `~/Library/Application Support/Code/User/settings.json` *(macOS)* — Default VS Code settings (Catppuccin theme, FiraCode font, fish terminal, Ruff formatter). Created on first apply only; your edits are never overwritten on `chezmoi update`.
+- `~/.config/Code/User/settings.json` *(Linux)* — Default VS Code settings (Catppuccin theme, FiraCode font, fish terminal, Ruff formatter). Created on first apply only; your edits are never overwritten on `chezmoi update`.
+- `~/Library/Application Support/Code/User/settings.json` *(macOS)* — Same default VS Code settings as the Linux path above. Created on first apply only; never overwritten on `chezmoi update`.
 
 ### Fish Shell Configuration ([Fish Shell Documentation](https://fishshell.com/docs/current/))
 - `~/.config/fish/config.fish` - Main Fish shell configuration
@@ -150,7 +151,7 @@ Re-run `chezmoi init` to update your module selection, then `chezmoi apply`.
 - `~/.config/nvim/init.lua` - Neovim editor configuration ([Neovim Documentation](https://neovim.io/doc/)) (requires `editor` module)
 
 ### macOS Window Manager
-- `~/.config/aerospace/aerospace.toml` - AeroSpace window manager ([AeroSpace Documentation](https://nikitabobko.github.io/AeroSpace/)) (requires `macos_desktop` module, macOS only)
+- `~/.config/aerospace/aerospace.toml` *(macOS)* - AeroSpace window manager ([AeroSpace Documentation](https://nikitabobko.github.io/AeroSpace/)) (requires `macos_desktop` module)
 
 ## Prerequisites
 

--- a/tests/readme.bats
+++ b/tests/readme.bats
@@ -6,26 +6,35 @@ setup() {
   load 'helpers/setup'
 }
 
-@test "all listed config paths exist in source" {
-  # Extract ~/. paths mentioned in the README and verify each exists in source.
-  # Handles chezmoi source naming variants: direct, .tmpl suffix, private_ prefix.
+@test "all listed config paths materialize after chezmoi apply" {
+  # Verify every ~/. path mentioned in the README is actually managed
+  # by chezmoi on this OS. Source-name agnostic: doesn't matter whether
+  # the source uses dot_, private_dot_, create_, .tmpl, etc. — only
+  # that `chezmoi managed` exposes the target.
+  H=$(mk_fake_home)
+  modules=$(awk '/^    modules:$/,/^[^ ]/{ if ($0 ~ /^      [a-z_]+:$/) { sub(":",""); gsub(" ",""); print } }' \
+            "$REPO_ROOT/.chezmoidata/packages.yaml" | jq -R . | jq -sc .)
+  seed_chezmoi_config "$H" "{\"modules\":$modules}"
+  managed=$(chezmoi_managed "$H")
+
+  # README marks OS-specific paths inline as *(Linux)* or *(macOS)*.
+  # Skip paths tagged for the other OS so each runner only validates
+  # what its own chezmoi will materialize.
+  case "$(uname)" in Darwin) other='*(Linux)*' ;; Linux) other='*(macOS)*' ;; *) other='__none__' ;; esac
+
   while IFS= read -r p; do
     [ -n "$p" ] || continue
-    # Convert chezmoi target path to source path:
-    # ~/.<name> → dot_<name>, e.g. ~/.config/fish/config.fish → dot_config/fish/config.fish
-    src=$(printf '%s\n' "$p" | sed 's|~/\.||')
-    src="dot_${src}"
-    dir=$(dirname "$REPO_ROOT/$src")
-    name=$(basename "$src")
-    # Accept: direct, .tmpl suffix, private_ prefix, or private_+.tmpl variants.
-    if ! test -e "$REPO_ROOT/$src" && \
-       ! test -e "$REPO_ROOT/${src}.tmpl" && \
-       ! test -e "$dir/private_${name}" && \
-       ! test -e "$dir/private_${name}.tmpl"; then
-      printf 'README lists path not found in source: %s\n' "$p" >&2
+    # Skip a path if the README line containing it is tagged for the other OS.
+    if grep -F "$p" "$REPO_ROOT/README.md" | grep -qF "$other"; then
+      continue
+    fi
+    rel="${p#'~/'}"  # quoted so bash doesn't tilde-expand the pattern
+    if ! printf '%s\n' "$managed" | grep -qxF "$rel"; then
+      printf 'README lists path not managed by chezmoi: %s\n' "$p" >&2
       return 1
     fi
-  done < <(grep -oE '~/[.][a-zA-Z0-9_./-]+' "$REPO_ROOT/README.md" | sort -u)
+  done < <(grep -oE '~/[.][a-zA-Z0-9_./-]+' "$REPO_ROOT/README.md" \
+           | grep -v '/$' | sort -u)
 }
 
 @test "old prereq language is gone" {


### PR DESCRIPTION
## Why

Main CI is currently red on `bats-linux` and `bats-macos`. After PR #80 (issue #69) merged, `README.md` references `~/.config/Code/User/settings.json` but the source ships it as `dot_config/Code/User/create_settings.json.tmpl`. The path-existence test in `tests/readme.bats` (added by #79) only knew about `dot_*`, `private_dot_*`, `*.tmpl` variants — not `create_*`.

This was missed in the PR #80 review/merge: PR #80's branch predated #79, so its branch CI never ran the path-existence test against the combined state, and `--admin` skipped the up-to-date-with-base check.

## What

Rewrite the test to use the standard hermetic pattern: seed a fake-home chezmoi config with every module enabled, then check each `~/.` path mentioned in the README appears in `chezmoi managed`. This is **source-name-agnostic** — chezmoi handles the prefix decoding, so we never need to teach the test about `create_`, future prefixes, or any source-naming convention.

OS-specific paths in the README are tagged inline (e.g. `*(Linux)*` / `*(macOS)*`). The test skips paths whose README line carries the other-OS tag, so each CI runner only validates what its own chezmoi will materialize.

## Test plan

- [x] `bats tests/readme.bats` green locally on darwin (3/3).
- [x] `bats tests/` green locally (25/25).
- [ ] CI: bats-linux + bats-macos must pass.