### PR TITLE
feat(packages): re-add git-extras to git_advanced module

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -46,6 +46,7 @@ packages:
           - 'difftastic'
           - 'git-cliff'
           - 'git-lfs'
+          - 'git-extras'
         casks: []
       atuin:
         brews:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Fish, Starship, Git, bat, eza, fd, fzf, ripgrep, zoxide, rip2, dust, bottom, dir
 |--------|----------|-------------|
 | `editor` | Neovim | Terminal editor with nvim aliases |
 | `terminal` | Ghostty | Modern GPU-accelerated terminal emulator |
-| `git_advanced` | jj, mergiraf, difftastic, git-cliff, git-lfs | Advanced version control tooling |
+| `git_advanced` | jj, mergiraf, difftastic, git-cliff, git-lfs, git-extras | Advanced version control tooling |
 | `atuin` | Atuin | Shell history sync across machines |
 | `python_dev` | nbdime, pre-commit (via uv) | Python/Jupyter development tools |
 | `gcloud` | Google Cloud SDK | Google Cloud CLI (cask on darwin, manual install on linux) |
@@ -112,7 +112,7 @@ Re-run `chezmoi init` to update your module selection, then `chezmoi apply`.
 ### Optional Module Highlights
 
 - 📝 **[Neovim](https://neovim.io/)** (`editor`) - A powerful text editor with syntax highlighting, plugins, and modern features
-- 🔄 **Advanced Git** (`git_advanced`) - Jujutsu, mergiraf, difftastic, git-cliff, and Git LFS
+- 🔄 **Advanced Git** (`git_advanced`) - [Jujutsu](https://github.com/jj-vcs/jj), [mergiraf](https://mergiraf.org/), [difftastic](https://github.com/Wilfred/difftastic), [git-cliff](https://git-cliff.org/), [Git LFS](https://git-lfs.com/), and [git-extras](https://github.com/tj/git-extras) (~80 helper subcommands like `git summary`, `git undo`, `git ignore`, `git wip`)
 - 📊 **Jupyter Notebook Support** (`python_dev`) - nbdime and pre-commit via uv
 - 🐋 **Container Development** (`cloud`) - [Colima](https://github.com/abiosoft/colima) for running Docker containers on macOS without Docker Desktop
 - ⏰ **Shell History** (`atuin`) - [Atuin](https://atuin.sh/) syncs your command history across machines with powerful search


### PR DESCRIPTION
## Summary

Restores `git-extras` to the `git_advanced` module. It was dropped during the modules refactor but `CHEATSHEET.md` and the original `CHANGELOG.md` still referenced it — so this is a regression-fix + doc-alignment.

`git-extras` ships ~80 helper subcommands (`git summary`, `git undo`, `git ignore`, `git wip`, `git changelog`, etc.), invoked as native `git <subcommand>`.

## Changes

- `.chezmoidata/packages.yaml` — add `git-extras` to `darwin.modules.git_advanced.brews`
- `README.md` — update module table + bullet description (with links for all 6 git_advanced tools, not just the new one)

## Closes

Closes #47

## Test plan

- [x] `bats tests/packages.bats tests/readme.bats tests/module_split.bats` — green
- [ ] CI green on push