### PR TITLE
docs(readme): add Starship customization links

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Re-run `chezmoi init` to update your module selection, then `chezmoi apply`.
 ### Shell Prompt
 - `~/.config/starship.toml` - Shell prompt configuration ([Starship Documentation](https://starship.rs/))
 
+#### Customizing Starship
+- [Configuration guide](https://starship.rs/config/) - module reference and syntax
+- [Presets gallery](https://starship.rs/presets/) - ready-made prompt styles
+- [Catppuccin theme](https://github.com/catppuccin/starship) - palette currently in use
+
 ### Development Tools
 - `~/.config/bat/config` - Syntax highlighter configuration ([Bat Documentation](https://github.com/sharkdp/bat))
 - `~/.config/direnv/direnvrc` - Environment management ([Direnv Documentation](https://direnv.net/))


### PR DESCRIPTION
Closes #50.

Adds a small "Customizing Starship" subsection under the Shell Prompt entry pointing to the official config guide, presets gallery, and the Catppuccin theme repo.