### PR TITLE
feat(vscode): add direnv extension

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -5,6 +5,7 @@ vscode:
     - 'ms-python.python'
     - 'ms-python.vscode-pylance'
     - 'charliermarsh.ruff'
+    - 'mkhl.direnv'
   modules: {}
 
 packages:

--- a/tests/vscode_extensions.bats
+++ b/tests/vscode_extensions.bats
@@ -18,10 +18,11 @@ setup() {
   done < <(yq -r '.vscode.extensions[]' "$REPO_ROOT/.chezmoidata/packages.yaml")
 }
 
-@test "refactor preserves the 5 default extensions" {
+@test "refactor preserves the 6 default extensions" {
   exts=$(yq -r '.vscode.extensions[]' "$REPO_ROOT/.chezmoidata/packages.yaml")
   for ext in "Catppuccin.catppuccin-vsc" "Catppuccin.catppuccin-vsc-icons" \
-             "ms-python.python" "ms-python.vscode-pylance" "charliermarsh.ruff"; do
+             "ms-python.python" "ms-python.vscode-pylance" "charliermarsh.ruff" \
+             "mkhl.direnv"; do
     if ! echo "$exts" | grep -qxF "$ext"; then
       echo "Expected extension '$ext' missing from packages.yaml" >&2
       return 1


### PR DESCRIPTION
Adds [`mkhl.direnv`](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv) to the core VS Code extensions so per-project envs from `.envrc` are available inside the editor (terminal, language servers, debuggers).

Updates the bats hardcoded count from 5 → 6.