### PR TITLE
fix(scripts/linux): gate git-extras and 1password installs by module

### DIFF
--- a/.chezmoiscripts/linux/run_onchange_install-1password-cli.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_install-1password-cli.sh.tmpl
@@ -1,5 +1,6 @@
-#!/bin/sh
 # chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
+# [[ if has "onepassword" .modules ]] #
+#!/bin/sh
 # shellcheck disable=SC2317
 
 # Install 1Password CLI (op) for Linux without requiring root
@@ -129,3 +130,4 @@ echo "1Password CLI installed successfully to ${HOME}/.local/bin/op"
 echo "Version: $("${HOME}"/.local/bin/op --version)"
 echo "Usage: op --help"
 echo "For service account creation: op service-account create \"My Service Account\" --can-create-vaults --expires-in 24h --vault Production:read_items,write_items"
+# [[ end ]] #

--- a/.chezmoiscripts/linux/run_onchange_install-git-extras.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_install-git-extras.sh.tmpl
@@ -1,5 +1,6 @@
-#!/bin/sh
 # chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
+# [[ if has "git_advanced" .modules ]] #
+#!/bin/sh
 # vim: set ft=bash:
 set -eu
 
@@ -43,3 +44,4 @@ cd - >/dev/null
 rm -rf "${TMP_DIR}"
 
 echo "git-extras has been installed to ${HOME}/.local/bin"
+# [[ end ]] #


### PR DESCRIPTION
On macOS, \`git-extras\` and \`1password-cli\` are gated behind the \`git_advanced\` and \`onepassword\` opt-in modules in \`.chezmoidata/packages.yaml\`. On Linux, the equivalent install scripts ran unconditionally — Linux users got tools they hadn't opted into and module behaviour was non-uniform across OSes.

Wraps both Linux scripts with the same \`# [[ if has "<module>" .modules ]] #\` pattern already used for \`atuin\` and \`gcloud\`.