### PR TITLE
fix(scripts/linux): restore line-1 shebang; add render-then-shellcheck and fish syntax tests

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -46,6 +46,16 @@ Library/Application Support/Code/User/settings.json
 {{ end }}
 {{ if not (has "atuin" .modules) }}
 .config/atuin/**
+.chezmoiscripts/linux/run_onchange_install-atuin.sh
+{{ end }}
+{{ if not (has "gcloud" .modules) }}
+.chezmoiscripts/linux/run_onchange_install-gcloud.sh
+{{ end }}
+{{ if not (has "git_advanced" .modules) }}
+.chezmoiscripts/linux/run_onchange_install-git-extras.sh
+{{ end }}
+{{ if not (has "onepassword" .modules) }}
+.chezmoiscripts/linux/run_onchange_install-1password-cli.sh
 {{ end }}
 {{ if or (eq .chezmoi.os "linux") (not (has "aerospace" .modules)) }}
 .config/aerospace/**

--- a/.chezmoiscripts/linux/run_onchange_install-1password-cli.sh.tmpl
+++ b/.chezmoiscripts/linux/run_onchange_install-1password-cli.sh.tmpl
@@ -1,6 +1,5 @@
-# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
-# [[ if has "onepassword" .modules ]] #
 #!/bin/sh
+# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
 # shellcheck disable=SC2317
 
 # Install 1Password CLI (op) for Linux without requiring root
@@ -130,4 +129,3 @@ echo "1Password CLI installed successfully to ${HOME}/.local/bin/op"
 echo "Version: $("${HOME}"/.local/bin/op --version)"
 echo "Usage: op --help"
 echo "For service account creation: op service-account create \"My Service Account\" --can-create-vaults --expires-in 24h --vault Production:read_items,write_items"
-# [[ end ]] #

--- a/.chezmoiscripts/linux/run_onchange_install-atuin.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-atuin.sh
@@ -1,5 +1,3 @@
-# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
-# [[ if has "atuin" .modules ]] #
 #!/bin/sh
 
 # Install atuin (shell history manager)
@@ -15,4 +13,3 @@ else
   echo "Installing atuin using the official installation script..."
   curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
 fi
-# [[ end ]] #

--- a/.chezmoiscripts/linux/run_onchange_install-gcloud.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-gcloud.sh
@@ -1,5 +1,3 @@
-# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
-# [[ if has "gcloud" .modules ]] #
 #!/bin/sh
 
 # This script installs Google Cloud SDK on Linux
@@ -88,4 +86,3 @@ fi
 echo "Cloud SDK installed to $INSTALL_DIR"
 echo "Path will be configured in Fish shell configuration automatically."
 echo "Note: To use 'gcloud' in this session, run: export PATH=\"$INSTALL_DIR/bin:\$PATH\""
-# [[ end ]] #

--- a/.chezmoiscripts/linux/run_onchange_install-git-extras.sh
+++ b/.chezmoiscripts/linux/run_onchange_install-git-extras.sh
@@ -1,5 +1,3 @@
-# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
-# [[ if has "git_advanced" .modules ]] #
 #!/bin/sh
 # vim: set ft=bash:
 set -eu
@@ -44,4 +42,3 @@ cd - >/dev/null
 rm -rf "${TMP_DIR}"
 
 echo "git-extras has been installed to ${HOME}/.local/bin"
-# [[ end ]] #

--- a/tests/fish_syntax.bats
+++ b/tests/fish_syntax.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# Parse-check fish config and functions so a stray syntax error in a
+# templated config or autoloaded function is caught before it lands.
+
+setup() {
+  load 'helpers/setup'
+  if ! command -v fish > /dev/null 2>&1; then
+    skip "fish not available"
+  fi
+}
+
+# Render a template through chezmoi, write to a temp file, fish -n it.
+_check_template() {
+  local h="$1" src="$2"
+  local out="$BATS_TEST_TMPDIR/$(basename "${src%.tmpl}")"
+  chezmoi_render "$h" "$src" > "$out"
+  fish -n "$out"
+}
+
+@test "config.fish.tmpl parses with no modules" {
+  H=$(mk_fake_home)
+  seed_chezmoi_config "$H" '{"modules":[]}'
+  _check_template "$H" dot_config/fish/config.fish.tmpl
+}
+
+@test "config.fish.tmpl parses with all modules" {
+  H=$(mk_fake_home)
+  all=$(yq -r '.packages.darwin.modules | keys | .[]' "$REPO_ROOT/.chezmoidata/packages.yaml" \
+        | jq -R . | jq -sc .)
+  seed_chezmoi_config "$H" "$(jq -nc --argjson m "$all" '{modules:$m}')"
+  _check_template "$H" dot_config/fish/config.fish.tmpl
+}
+
+@test "aliases.fish.tmpl parses" {
+  H=$(mk_fake_home)
+  seed_chezmoi_config "$H" '{"modules":[]}'
+  _check_template "$H" dot_config/fish/aliases.fish.tmpl
+}
+
+@test "private_artefiles_abbrs.fish parses" {
+  fish -n "$REPO_ROOT/dot_config/fish/conf.d/private_artefiles_abbrs.fish"
+}
+
+@test "all autoloaded fish functions parse" {
+  for f in "$REPO_ROOT"/dot_config/fish/functions/*.fish; do
+    fish -n "$f"
+  done
+}

--- a/tests/install_linux.bats
+++ b/tests/install_linux.bats
@@ -15,6 +15,31 @@ setup() {
   printf '%s\n' "$rendered" | shellcheck -
 }
 
+@test "every linux install script shellchecks after rendering" {
+  if ! command -v shellcheck > /dev/null 2>&1; then
+    skip "shellcheck not available"
+  fi
+  H=$(mk_fake_home)
+  all=$(yq -r '.packages.darwin.modules | keys | .[]' "$REPO_ROOT/.chezmoidata/packages.yaml" \
+        | jq -R . | jq -sc .)
+  seed_chezmoi_config "$H" "$(jq -nc --argjson m "$all" '{modules:$m}')"
+  for f in "$REPO_ROOT"/.chezmoiscripts/linux/*.sh "$REPO_ROOT"/.chezmoiscripts/linux/*.sh.tmpl; do
+    [ -f "$f" ] || continue
+    rel=${f#"$REPO_ROOT"/}
+    out="$BATS_TEST_TMPDIR/$(basename "${rel%.tmpl}")"
+    if [[ "$f" == *.tmpl ]]; then
+      chezmoi_render "$H" "$rel" > "$out"
+    else
+      cp "$f" "$out"
+    fi
+    if ! shellcheck -S error "$out" 2>"$BATS_TEST_TMPDIR/err"; then
+      echo "shellcheck failed on rendered $rel:" >&2
+      cat "$BATS_TEST_TMPDIR/err" >&2
+      return 1
+    fi
+  done
+}
+
 @test "gh install script is a no-op if local gh is already the latest version" {
   H=$(mk_fake_home)
   seed_chezmoi_config "$H" '{"modules":[]}'


### PR DESCRIPTION
## The bug

Four Linux install scripts wrapped their bodies with a per-module guard:

\`\`\`
# chezmoi:template:left-delimiter="# [[" right-delimiter="]] #"
# [[ if has "<module>" .modules ]] #
#!/bin/sh
...
# [[ end ]] #
\`\`\`

Both the chezmoi template directive and the if-directive line are output verbatim (or as a stray newline), so the rendered shebang ended up on line 2 or 3 — shellcheck SC1128. Today it works because the kernel falls back to \`/bin/sh\`, but it's fragile and the scripts can't be linted end-to-end.

PR #88 propagated this same pattern to git-extras + 1password-cli; atuin and gcloud had it from earlier.

## The fix

Move per-module gating from inline template wrappers into \`.chezmoiignore\`, the same pattern already used for \`.config/atuin/**\`, \`.config/ghostty/**\`, etc. The scripts become plain shell with \`#!/bin/sh\` on line 1.

- \`run_onchange_install-atuin.sh.tmpl\` → \`.sh\` (no other templating)
- \`run_onchange_install-gcloud.sh.tmpl\` → \`.sh\` (no other templating)
- \`run_onchange_install-git-extras.sh.tmpl\` → \`.sh\` (no other templating)
- \`run_onchange_install-1password-cli.sh.tmpl\` — kept as \`.tmpl\` for arch detection; chezmoi:template directive moved to line 2 so \`#!/bin/sh\` is line 1.

\`.chezmoiignore\` extended with the four scripts gated on \`atuin\`, \`gcloud\`, \`git_advanced\`, \`onepassword\` modules respectively.

## Why tests didn't catch it

\`tests/install_linux.bats\` only shellchecked the \`gh\` install script. Adding two regression tests:

- **\`every linux install script shellchecks after rendering\`** — enumerates every \`.chezmoiscripts/linux/*.sh{,.tmpl}\`, renders with all modules enabled, runs \`shellcheck -S error\`. This would have caught the SC1128 on day 1.
- **\`tests/fish_syntax.bats\`** (new file) — \`fish -n\` on rendered \`config.fish.tmpl\` (empty + all modules), \`aliases.fish.tmpl\`, \`private_artefiles_abbrs.fish\`, and every \`dot_config/fish/functions/*.fish\`. Catches stray syntax errors in fish config and autoloaded functions.

Full suite: 41/41 passing.