### PR TITLE
refactor(chezmoiignore): remove redundant aerospace and linux-script gates

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -23,6 +23,8 @@ docker-test.sh
 # Exclude macOS-specific files on Linux
 .chezmoiscripts/darwin/**
 Library/Application Support/Code/User/settings.json
+# aerospace is a darwin-only window manager (see packages.darwin.modules)
+.config/aerospace/**
 {{ end }}
 
 # Remote SSH server exclusions (when SSH_CLIENT is present)
@@ -37,31 +39,39 @@ Library/Application Support/Code/User/settings.json
 
 # Module-based exclusions.
 # Patterns match TARGET paths (chezmoi strips dot_/private_/.tmpl before
-# matching), so use ".config/..." not "dot_config/...".
+# matching, and run_<modifier>_ from script targets), so use ".config/..."
+# not "dot_config/...".
 {{ if not (has "editor" .modules) }}
 .config/nvim/**
 {{ end }}
 {{ if not (has "terminal" .modules) }}
 .config/ghostty/**
 {{ end }}
+{{ if and (eq .chezmoi.os "darwin") (not (has "aerospace" .modules)) }}
+.config/aerospace/**
+{{ end }}
 {{ if not (has "atuin" .modules) }}
 .config/atuin/**
-.chezmoiscripts/linux/install-atuin.sh
-{{ end }}
-{{ if not (has "gcloud" .modules) }}
-.chezmoiscripts/linux/install-gcloud.sh
-{{ end }}
-{{ if not (has "git_advanced" .modules) }}
-.chezmoiscripts/linux/install-git-extras.sh
-{{ end }}
-{{ if not (has "onepassword" .modules) }}
-.chezmoiscripts/linux/install-1password-cli.sh
-{{ end }}
-{{ if or (eq .chezmoi.os "linux") (not (has "aerospace" .modules)) }}
-.config/aerospace/**
 {{ end }}
 {{ if not (has "python_dev" .modules) }}
 .chezmoiscripts/zzzzz_install-python-tools.sh
+{{ end }}
+
+# Per-module linux install scripts. On darwin .chezmoiscripts/linux/** above
+# already excludes them, so only emit these gates on linux.
+{{ if eq .chezmoi.os "linux" }}
+{{   if not (has "atuin" .modules) }}
+.chezmoiscripts/linux/install-atuin.sh
+{{   end }}
+{{   if not (has "gcloud" .modules) }}
+.chezmoiscripts/linux/install-gcloud.sh
+{{   end }}
+{{   if not (has "git_advanced" .modules) }}
+.chezmoiscripts/linux/install-git-extras.sh
+{{   end }}
+{{   if not (has "onepassword" .modules) }}
+.chezmoiscripts/linux/install-1password-cli.sh
+{{   end }}
 {{ end }}
 
 **/*.old.*


### PR DESCRIPTION
Two minor redundancies surfaced by the post-#92 review:

1. **Aerospace exclusion was conditioned twice.** \`{{ if or (eq .chezmoi.os "linux") (not (has "aerospace" .modules)) }}\` mixed an OS rule and a module rule. Aerospace is darwin-only (cask under \`packages.darwin.modules.aerospace\`), so the linux side belongs in the OS-exclusion branch. Split into:
   - \`linux\` branch → unconditionally ignore \`.config/aerospace/**\`
   - module section → ignore when \`aerospace\` module is off

2. **Per-module linux install-script ignores were redundant on darwin.** \`.chezmoiscripts/linux/**\` in the darwin OS branch already excludes them all; the per-module entries fired anyway and rendered duplicate exclusion lines. Wrapped them in \`{{ if eq .chezmoi.os "linux" }}\` so they only emit where they're actually needed.

No behavior change — verified by 53/53 bats pass and a render diff under empty-modules / all-modules / linux / darwin.