### PR TITLE
test(shellcheck): cover all rendered .chezmoiscripts under both OSes

### DIFF
--- a/tests/install_linux.bats
+++ b/tests/install_linux.bats
@@ -15,31 +15,6 @@ setup() {
   printf '%s\n' "$rendered" | shellcheck -
 }
 
-@test "every linux install script shellchecks after rendering" {
-  if ! command -v shellcheck > /dev/null 2>&1; then
-    skip "shellcheck not available"
-  fi
-  H=$(mk_fake_home)
-  all=$(yq -r '.packages.darwin.modules | keys | .[]' "$REPO_ROOT/.chezmoidata/packages.yaml" \
-        | jq -R . | jq -sc .)
-  seed_chezmoi_config "$H" "$(jq -nc --argjson m "$all" '{modules:$m}')"
-  for f in "$REPO_ROOT"/.chezmoiscripts/linux/*.sh "$REPO_ROOT"/.chezmoiscripts/linux/*.sh.tmpl; do
-    [ -f "$f" ] || continue
-    rel=${f#"$REPO_ROOT"/}
-    out="$BATS_TEST_TMPDIR/$(basename "${rel%.tmpl}")"
-    if [[ "$f" == *.tmpl ]]; then
-      chezmoi_render "$H" "$rel" > "$out"
-    else
-      cp "$f" "$out"
-    fi
-    if ! shellcheck -S error "$out" 2>"$BATS_TEST_TMPDIR/err"; then
-      echo "shellcheck failed on rendered $rel:" >&2
-      cat "$BATS_TEST_TMPDIR/err" >&2
-      return 1
-    fi
-  done
-}
-
 @test "gh install script is a no-op if local gh is already the latest version" {
   H=$(mk_fake_home)
   seed_chezmoi_config "$H" '{"modules":[]}'

--- a/tests/shellcheck.bats
+++ b/tests/shellcheck.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# Render every templated/plain shell script under .chezmoiscripts and run
+# shellcheck against the rendered output. Catches SC1128 (shebang not on
+# line 1), unquoted expansions, and other real shell bugs that escape eyes
+# during review. Renders with all modules enabled so per-module gates emit.
+
+setup() {
+  load 'helpers/setup'
+  if ! command -v shellcheck > /dev/null 2>&1; then
+    skip "shellcheck not available"
+  fi
+}
+
+_shellcheck_dir() {
+  local dir="$1"
+  H=$(mk_fake_home)
+  all=$(yq -r '.packages.darwin.modules | keys | .[]' "$REPO_ROOT/.chezmoidata/packages.yaml" \
+        | jq -R . | jq -sc .)
+  seed_chezmoi_config "$H" "$(jq -nc --argjson m "$all" '{modules:$m}')"
+
+  for f in "$REPO_ROOT"/$dir/*.sh "$REPO_ROOT"/$dir/*.sh.tmpl; do
+    [ -f "$f" ] || continue
+    rel=${f#"$REPO_ROOT"/}
+    out="$BATS_TEST_TMPDIR/$(basename "${rel%.tmpl}")"
+    if [[ "$f" == *.tmpl ]]; then
+      chezmoi_render "$H" "$rel" > "$out"
+    else
+      cp "$f" "$out"
+    fi
+    if ! shellcheck -S error "$out" 2>"$BATS_TEST_TMPDIR/err"; then
+      echo "shellcheck failed on rendered $rel:" >&2
+      cat "$BATS_TEST_TMPDIR/err" >&2
+      return 1
+    fi
+  done
+}
+
+@test "every linux install script shellchecks after rendering" {
+  _shellcheck_dir .chezmoiscripts/linux
+}
+
+@test "every darwin install script shellchecks after rendering" {
+  _shellcheck_dir .chezmoiscripts/darwin
+}
+
+@test "every cross-OS install script shellchecks after rendering" {
+  _shellcheck_dir .chezmoiscripts
+}


### PR DESCRIPTION
\`tests/install_linux.bats\` shellchecked rendered \`.chezmoiscripts/linux/*\` only — darwin and root scripts were unverified. PR #91's regression (SC1128 from misplaced shebangs) was caught for linux because of that test; the same class of bug in darwin/ or root/ would have shipped silently.

New \`tests/shellcheck.bats\` enumerates every \`.sh\`/\`.sh.tmpl\` under:
- \`.chezmoiscripts/linux/\`
- \`.chezmoiscripts/darwin/\`
- \`.chezmoiscripts/\` (root, cross-OS)

renders each with all modules enabled, runs \`shellcheck -S error\`. Skips when shellcheck isn't installed.

The redundant per-linux test in \`install_linux.bats\` is removed (the new file covers it). Verified locally — all 7 darwin/root scripts pass after rendering.

Suite: 53 → 55 tests.

Fish scripts are already covered by \`tests/fish_syntax.bats\` (\`fish -n\`) — no equivalent needed.