### PR TITLE
fix(nvim): restore init.lua.tmpl — file has darwin-conditional template logic

### DIFF
--- a/dot_config/nvim/init.lua.tmpl
+++ b/dot_config/nvim/init.lua.tmpl
@@ -1,3 +1,4 @@
+-- chezmoi:template:left-delimiter="-- [[" right-delimiter="]] --"
 -- Neovim Configuration
 -- Fast, focused configuration for efficient editing
 

--- a/tests/module_gating.bats
+++ b/tests/module_gating.bats
@@ -76,11 +76,6 @@ _assert_script_gating() {
   fi
 }
 
-@test "atuin module gates its linux install script" {
-  [ "$(uname -s)" = Linux ] || skip "linux-only script"
-  _assert_script_gating atuin .chezmoiscripts/linux/install-atuin.sh
-}
-
 @test "gcloud module gates its linux install script" {
   [ "$(uname -s)" = Linux ] || skip "linux-only script"
   _assert_script_gating gcloud .chezmoiscripts/linux/install-gcloud.sh


### PR DESCRIPTION
**Regression in #95.** I dropped \`dot_config/nvim/init.lua.tmpl\`'s \`.tmpl\` extension and chezmoi:template directive after greping for \`{{\` and \`# [[\` and finding none. I missed that the file uses \`-- [[ ... ]] --\` (Lua-comment-friendly delimiters) — there are two real \`if eq .chezmoi.os "darwin"\` blocks at lines 681-688 and 725-732 that gate macOS-specific LSP setup.

**Effect on main:** chezmoi now applies \`init.lua\` as a plain file. The OS conditionals are output as literal Lua comments — Lua ignores them so neovim doesn't error, but the macOS-specific LSP block (\`bashls\`, \`clangd\`, \`cssls\`, \`html\`, \`jsonls\`) emits unconditionally on Linux. Neovim will try to spawn those servers without them being installed on Linux.

**Fix:** rename back to \`init.lua.tmpl\` + restore the \`-- chezmoi:template:\` directive on line 1.

Also drops the \`atuin module gates its linux install script\` test from #95 — the install script no longer exists (atuin is handled via externals only), so the test asserts on a non-existent target. Should have been part of #95.

54/54 tests pass. Verified rendered nvim correctly omits the directive lines and emits darwin-only LSPs only on darwin.